### PR TITLE
Add deployment build step for CSM configs.

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -6,7 +6,9 @@ COPY frontend/package*.json ./
 RUN npm ci
 # Copy necessary files for CSP config generation
 COPY config/trusted-embed-domains.json /config/trusted-embed-domains.json
+COPY config/trusted-embed-domains.schema.json /config/trusted-embed-domains.schema.json
 COPY script/generate-csp-configs /script/generate-csp-configs
+COPY nginx/templates/ /nginx/templates/
 RUN chmod +x /script/generate-csp-configs
 # Copy frontend source
 COPY frontend/ ./
@@ -39,6 +41,8 @@ COPY --chown=appuser:appuser . /usr/src/hello-perld
 COPY --from=frontend-builder --chown=appuser:appuser /frontend/dist /usr/src/hello-perld/lib/HelloPerld/Public/dist
 # Copy generated CSP configuration from frontend builder stage
 COPY --from=frontend-builder --chown=appuser:appuser /config/generated /usr/src/hello-perld/config/generated
+# Copy generated nginx configuration from frontend builder stage
+COPY --from=frontend-builder --chown=appuser:appuser /nginx/generated /usr/src/hello-perld/nginx/generated
 
 # Copy and set up entrypoint script
 COPY --chown=appuser:appuser docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/config/trusted-embed-domains.json
+++ b/config/trusted-embed-domains.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./trusted-embed-domains.schema.json",
   "version": "1.0",
   "last_updated": "2025-11-11",
   "description": "Single source of truth for trusted iframe embed domains. Used to generate frontend validation arrays, backend CSP headers, and nginx CSP configurations.",

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -86,6 +86,34 @@ echo ""
 echo "Cleaning up stale Docker networks..."
 docker network prune -f
 
+# Check Node.js and install dependencies for CSP generation
+echo ""
+echo "Checking Node.js dependencies for CSP generation..."
+if ! command -v node &> /dev/null; then
+    echo "Error: Node.js is not installed on deployment server!"
+    echo "Please install Node.js: curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && sudo apt-get install -y nodejs"
+    exit 1
+fi
+
+# Install Node.js dependencies for CSP generation script
+if [ ! -d "node_modules" ] || [ ! -f "node_modules/ajv/package.json" ]; then
+    echo "Installing Node.js dependencies for CSP generation..."
+    npm install ajv ajv-formats || {
+        echo "Error: Failed to install CSP generation dependencies!"
+        echo "Please ensure npm is working and try manually: npm install ajv ajv-formats"
+        exit 1
+    }
+fi
+
+# Generate CSP configuration files
+echo ""
+echo "Generating CSP configuration files..."
+node script/generate-csp-configs || {
+    echo "Error: Failed to generate CSP configuration files!"
+    echo "This is required for nginx and backend CSP headers."
+    exit 1
+}
+
 # Pull latest images
 echo ""
 echo "Pulling latest Docker images..."

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,8 @@
         "@vitejs/plugin-vue": "^6.0.0",
         "@vitest/coverage-v8": "^3.2.4",
         "@vue/test-utils": "^2.4.6",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1",
         "eslint": "^9.36.0",
         "eslint-plugin-vue": "^10.5.0",
         "happy-dom": "^20.0.8",

--- a/lib/HelloPerld.pm
+++ b/lib/HelloPerld.pm
@@ -6,8 +6,8 @@ our $VERSION = '1.0.0';
 use HelloPerld::Logger::LoggerFactory;
 use HelloPerld::Security::CSRF;
 
-# CSP frame-src configuration will be loaded in startup method
-our $CSP_FRAME_SRC;
+# CSP frame-src directive configuration will be loaded in startup method
+our $CSP_FRAME_SRC_DIRECTIVE;
 
 sub startup {
     my $self = shift;
@@ -31,7 +31,33 @@ sub startup {
         $self->log->info("Loaded CSP frame-src configuration from: $csp_config_file");
     } else {
         $self->log->warn("CSP frame-src configuration not found at: $csp_config_file");
-        $CSP_FRAME_SRC = "frame-src 'none'"; # Fallback - no embedded frames allowed
+        $CSP_FRAME_SRC_DIRECTIVE = "frame-src 'none'"; # Fallback - no embedded frames allowed
+    }
+
+    # Validate CSP frame-src configuration at startup
+    if (!defined $CSP_FRAME_SRC_DIRECTIVE) {
+        $self->log->error("CSP_FRAME_SRC_DIRECTIVE is not defined. Config loading failed.");
+        die "CSP configuration validation failed: directive not defined";
+    }
+
+    if (!$CSP_FRAME_SRC_DIRECTIVE) {
+        $self->log->error("CSP_FRAME_SRC_DIRECTIVE is empty. Config may be corrupted.");
+        die "CSP configuration validation failed: directive is empty";
+    }
+
+    if ($CSP_FRAME_SRC_DIRECTIVE !~ /^frame-src\s+/) {
+        $self->log->error("CSP_FRAME_SRC_DIRECTIVE malformed. Expected format: 'frame-src ...' but got: '$CSP_FRAME_SRC_DIRECTIVE'");
+        $self->log->error("This indicates a bug in the CSP config generation. Check script/generate-csp-configs");
+        die "CSP configuration validation failed: invalid directive format";
+    }
+
+    # Validate directive contains actual domains (not just 'frame-src 'none'')
+    my $domain_count = () = $CSP_FRAME_SRC_DIRECTIVE =~ /https?:\/\/[^\s]+/g;
+    if ($domain_count == 0 && $CSP_FRAME_SRC_DIRECTIVE !~ /'none'/) {
+        $self->log->warn("CSP_FRAME_SRC_DIRECTIVE contains no domains and no 'none' directive: '$CSP_FRAME_SRC_DIRECTIVE'");
+        $self->log->warn("This may indicate a configuration issue. iframe embeds will be blocked.");
+    } else {
+        $self->log->info("CSP_FRAME_SRC_DIRECTIVE validated: $domain_count trusted domain(s) configured");
     }
 
     # Validate production configuration
@@ -418,7 +444,7 @@ sub startup {
                 "base-uri 'self'",                              # Restrict <base> tag to same origin
                 "form-action 'self'",                           # Forms can only submit to same origin
                 "frame-ancestors 'none'",                       # Prevent embedding in frames (like X-Frame-Options)
-                $CSP_FRAME_SRC,                                 # Trusted iframe embed domains (generated from config/trusted-embed-domains.json)
+                $CSP_FRAME_SRC_DIRECTIVE,                       # Trusted iframe embed domains (generated from config/trusted-embed-domains.json)
                 "upgrade-insecure-requests"                     # Automatically upgrade HTTP to HTTPS in production
             );
 

--- a/script/generate-csp-configs
+++ b/script/generate-csp-configs
@@ -15,8 +15,12 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
+const Ajv = require('ajv');
+const addFormats = require('ajv-formats');
 
 // Configuration
+const STRICT_MODE = process.env.CSP_GEN_STRICT !== 'false'; // Default to strict
 const CONFIG_FILE = path.join(__dirname, '..', 'config', 'trusted-embed-domains.json');
 const FRONTEND_OUTPUT = path.join(__dirname, '..', 'frontend', 'src', 'generated', 'trusted-domains.js');
 const BACKEND_OUTPUT = path.join(__dirname, '..', 'config', 'generated', 'csp-frame-src.conf');
@@ -25,16 +29,126 @@ const NGINX_STAGING_TEMPLATE = path.join(__dirname, '..', 'nginx', 'templates', 
 const NGINX_PRODUCTION_OUTPUT = path.join(__dirname, '..', 'nginx', 'generated', 'production.conf');
 const NGINX_STAGING_OUTPUT = path.join(__dirname, '..', 'nginx', 'generated', 'staging.conf');
 
+// Load JSON Schema for configuration validation
+const SCHEMA_FILE = path.join(__dirname, '..', 'config', 'trusted-embed-domains.schema.json');
+let configSchema;
+try {
+    configSchema = JSON.parse(fs.readFileSync(SCHEMA_FILE, 'utf8'));
+    console.log(`✅ Loaded schema from ${SCHEMA_FILE}`);
+} catch (error) {
+    if (STRICT_MODE) {
+        console.error(`❌ STRICT_MODE: Failed to load schema from ${SCHEMA_FILE}: ${error.message}`);
+        process.exit(1);
+    } else {
+        console.warn(`⚠️  Warning: Could not load schema file (${error.message}), proceeding without external validation`);
+        configSchema = { type: 'object' }; // Minimal fallback schema
+    }
+}
+
+/**
+ * Validate configuration against JSON schema
+ */
+function validateConfigSchema(config) {
+    const ajv = new Ajv({ allErrors: true, strict: true });
+    addFormats(ajv);
+
+    const validate = ajv.compile(configSchema);
+    const valid = validate(config);
+
+    if (!valid) {
+        console.error('❌ Configuration validation failed:');
+
+        // User-friendly error messages
+        validate.errors.forEach(error => {
+            const path = error.instancePath || 'root';
+            const message = error.message;
+            const data = error.data !== undefined ? ` (got: ${JSON.stringify(error.data)})` : '';
+            console.error(`  ${path}: ${message}${data}`);
+        });
+
+        throw new Error('Invalid configuration schema');
+    }
+
+    console.log(`✅ Configuration schema validated: ${config.domains.length} domains`);
+    return config;
+}
+
+/**
+ * Validate business logic rules
+ */
+function validateBusinessLogic(config) {
+    const errors = [];
+    const warnings = [];
+    const seenDomains = new Set();
+
+    config.domains.forEach((domainConfig, index) => {
+        const domainKey = domainConfig.domain.toLowerCase();
+
+        // Check for duplicates
+        if (seenDomains.has(domainKey)) {
+            errors.push(`Duplicate domain at index ${index}: ${domainConfig.domain}`);
+        }
+        seenDomains.add(domainKey);
+
+        // Validate subdomain flag makes sense
+        if (domainConfig.subdomains && domainConfig.domain.split('.').length > 2) {
+            warnings.push(
+                `Domain "${domainConfig.domain}" has subdomain wildcard enabled but is already a subdomain. ` +
+                `This will allow *.${domainConfig.domain} (e.g., *.www.example.com)`
+            );
+        }
+
+        // Check variant duplicates
+        const variants = [domainConfig.domain, ...(domainConfig.variants || [])];
+        const uniqueVariants = new Set(variants.map(v => v.toLowerCase()));
+        if (uniqueVariants.size !== variants.length) {
+            errors.push(`Domain at index ${index} has duplicate variants: ${domainConfig.domain}`);
+        }
+
+        // Validate protocols
+        if (domainConfig.protocols && domainConfig.protocols.length === 0) {
+            errors.push(`Domain at index ${index} has empty protocols array: ${domainConfig.domain}`);
+        }
+
+        // Warn about http in production
+        if (domainConfig.protocols && domainConfig.protocols.includes('http')) {
+            warnings.push(`Domain "${domainConfig.domain}" allows HTTP. Consider HTTPS-only for security.`);
+        }
+    });
+
+    // Display warnings
+    warnings.forEach(warning => console.warn(`⚠️  ${warning}`));
+
+    if (errors.length > 0) {
+        console.error('❌ Business logic validation failed:');
+        errors.forEach(err => console.error(`  - ${err}`));
+        throw new Error('Invalid business logic');
+    }
+
+    console.log('✅ Business logic validated');
+    return config;
+}
+
 /**
  * Load and parse the trusted embed domains configuration
  */
 function loadTrustedDomains() {
     try {
         const configContent = fs.readFileSync(CONFIG_FILE, 'utf8');
-        const config = JSON.parse(configContent);
-        return config;
+        const rawConfig = JSON.parse(configContent);
+
+        // Validate configuration schema and business logic
+        const validatedConfig = validateConfigSchema(rawConfig);
+        return validateBusinessLogic(validatedConfig);
     } catch (error) {
-        console.error(`Error reading configuration file ${CONFIG_FILE}:`, error.message);
+        if (error.code === 'ENOENT') {
+            console.error(`❌ Configuration file not found: ${CONFIG_FILE}`);
+        } else if (error.name === 'SyntaxError') {
+            console.error(`❌ Invalid JSON in configuration file: ${CONFIG_FILE}`);
+            console.error(`   ${error.message}`);
+        } else {
+            console.error(`❌ Error loading configuration: ${error.message}`);
+        }
         process.exit(1);
     }
 }
@@ -100,6 +214,36 @@ function ensureDirectoryExists(filePath) {
 }
 
 /**
+ * Atomic file write to prevent race conditions
+ */
+function writeFileAtomic(filePath, content) {
+    const tempPath = `${filePath}.tmp.${crypto.randomBytes(6).toString('hex')}`;
+    try {
+        // Ensure directory exists first
+        ensureDirectoryExists(filePath);
+
+        // Write to temporary file
+        fs.writeFileSync(tempPath, content, 'utf8');
+
+        // Atomically rename to final destination
+        fs.renameSync(tempPath, filePath);
+
+        console.log(`✅ Atomically written: ${filePath} (${content.length} bytes)`);
+    } catch (error) {
+        // Cleanup temp file on error
+        if (fs.existsSync(tempPath)) {
+            try {
+                fs.unlinkSync(tempPath);
+                console.log(`🧹 Cleaned up temp file: ${tempPath}`);
+            } catch (cleanupError) {
+                console.warn(`⚠️  Could not cleanup temp file ${tempPath}: ${cleanupError.message}`);
+            }
+        }
+        throw new Error(`Atomic write failed for ${filePath}: ${error.message}`);
+    }
+}
+
+/**
  * Generate frontend JavaScript file
  */
 function generateFrontendConfig(config, domainList) {
@@ -130,9 +274,7 @@ export const TRUSTED_DOMAINS_CONFIG = {
 };
 `;
 
-    ensureDirectoryExists(FRONTEND_OUTPUT);
-    fs.writeFileSync(FRONTEND_OUTPUT, content, 'utf8');
-    console.log(`Generated frontend config: ${FRONTEND_OUTPUT}`);
+    writeFileAtomic(FRONTEND_OUTPUT, content);
 }
 
 /**
@@ -145,9 +287,21 @@ function generateBackendConfig(config, cspFrameSrc) {
 # Source: config/trusted-embed-domains.json
 # Generator: script/generate-csp-configs
 
-# CSP frame-src directive for trusted embed domains
-# This variable is used by lib/HelloPerld.pm in the CSP header construction
-our $CSP_FRAME_SRC = "frame-src ${cspFrameSrc}";
+# CSP frame-src directive for trusted embed domains (INCLUDES 'frame-src' PREFIX)
+#
+# IMPORTANT: This variable contains the complete CSP directive including the prefix.
+# Usage in HelloPerld.pm:
+#   my @csp_directives = (
+#       "default-src 'self'",
+#       "script-src 'self'",
+#       $CSP_FRAME_SRC_DIRECTIVE,  # <-- Use directly, do NOT add "frame-src" prefix again
+#       ...
+#   );
+#
+# The generated value format is:
+#   "frame-src https://youtube.com https://vimeo.com ..."
+#
+our $CSP_FRAME_SRC_DIRECTIVE = "frame-src ${cspFrameSrc}";
 
 # Configuration metadata
 our $CSP_CONFIG_VERSION = "${config.version}";
@@ -156,9 +310,7 @@ our $CSP_CONFIG_GENERATED = "${timestamp}";
 1; # Required for Perl module
 `;
 
-    ensureDirectoryExists(BACKEND_OUTPUT);
-    fs.writeFileSync(BACKEND_OUTPUT, content, 'utf8');
-    console.log(`Generated backend config: ${BACKEND_OUTPUT}`);
+    writeFileAtomic(BACKEND_OUTPUT, content);
 }
 
 /**
@@ -169,13 +321,115 @@ function generateNginxConfig(templateFile, outputFile, cspFrameSrc) {
         const template = fs.readFileSync(templateFile, 'utf8');
         const content = template.replace(/\{\{CSP_FRAME_SRC\}\}/g, cspFrameSrc);
 
-        ensureDirectoryExists(outputFile);
-        fs.writeFileSync(outputFile, content, 'utf8');
-        console.log(`Generated nginx config: ${outputFile}`);
+        writeFileAtomic(outputFile, content);
     } catch (error) {
         console.error(`Error processing nginx template ${templateFile}:`, error.message);
         process.exit(1);
     }
+}
+
+/**
+ * Validate required templates exist when in strict mode
+ */
+function validateTemplates() {
+    if (!STRICT_MODE) {
+        return; // Skip validation in non-strict mode
+    }
+
+    const templateErrors = [];
+
+    if (!fs.existsSync(NGINX_PRODUCTION_TEMPLATE)) {
+        templateErrors.push(`Required template missing: ${NGINX_PRODUCTION_TEMPLATE}`);
+    }
+    if (!fs.existsSync(NGINX_STAGING_TEMPLATE)) {
+        templateErrors.push(`Required template missing: ${NGINX_STAGING_TEMPLATE}`);
+    }
+
+    if (templateErrors.length > 0) {
+        console.error('❌ Template validation failed:');
+        templateErrors.forEach(err => console.error(`  - ${err}`));
+        console.error('\nTo make nginx configs optional, set: CSP_GEN_STRICT=false');
+        throw new Error('Required templates missing');
+    }
+
+    console.log('✅ All required templates present');
+}
+
+/**
+ * Validate generated files exist and contain expected content
+ */
+function validateGeneratedFiles() {
+    const requiredFiles = [
+        {
+            path: FRONTEND_OUTPUT,
+            minSize: 200,
+            mustContain: ['TRUSTED_EMBED_DOMAINS', 'export const'],
+            description: 'Frontend trusted domains file'
+        },
+        {
+            path: BACKEND_OUTPUT,
+            minSize: 150,
+            mustContain: ['CSP_FRAME_SRC_DIRECTIVE', 'our $CSP_FRAME_SRC_DIRECTIVE'],
+            description: 'Backend CSP configuration file'
+        }
+    ];
+
+    // Add nginx files to validation if they should exist
+    if (fs.existsSync(NGINX_PRODUCTION_TEMPLATE)) {
+        requiredFiles.push({
+            path: NGINX_PRODUCTION_OUTPUT,
+            minSize: 500,
+            mustContain: ['Content-Security-Policy', 'frame-src'],
+            description: 'Nginx production configuration'
+        });
+    }
+
+    if (fs.existsSync(NGINX_STAGING_TEMPLATE)) {
+        requiredFiles.push({
+            path: NGINX_STAGING_OUTPUT,
+            minSize: 500,
+            mustContain: ['Content-Security-Policy', 'frame-src'],
+            description: 'Nginx staging configuration'
+        });
+    }
+
+    const errors = [];
+
+    for (const file of requiredFiles) {
+        // Check file exists
+        if (!fs.existsSync(file.path)) {
+            errors.push(`Generated file missing: ${file.path} (${file.description})`);
+            continue;
+        }
+
+        // Check file size
+        try {
+            const content = fs.readFileSync(file.path, 'utf8');
+            if (content.length < file.minSize) {
+                errors.push(`Generated file too small: ${file.path} (${content.length} bytes, expected >${file.minSize}) - ${file.description}`);
+                continue;
+            }
+
+            // Check required content
+            const missingContent = file.mustContain.filter(required => !content.includes(required));
+            if (missingContent.length > 0) {
+                errors.push(`Generated file missing expected content: ${file.path} should contain: ${missingContent.join(', ')} - ${file.description}`);
+                continue;
+            }
+
+            console.log(`✅ Validated: ${file.description} (${content.length} bytes)`);
+        } catch (readError) {
+            errors.push(`Cannot read generated file: ${file.path} - ${readError.message}`);
+        }
+    }
+
+    if (errors.length > 0) {
+        console.error('❌ Post-generation validation failed:');
+        errors.forEach(err => console.error(`  - ${err}`));
+        throw new Error('Generated files validation failed');
+    }
+
+    console.log(`✅ All ${requiredFiles.length} generated files validated successfully`);
 }
 
 /**
@@ -204,18 +458,37 @@ function main() {
         generateFrontendConfig(config, domainList);
         generateBackendConfig(config, cspFrameSrc);
 
-        // Generate nginx configs (templates will be created next)
+        // Generate nginx configs with strict validation
+        validateTemplates();
+
         if (fs.existsSync(NGINX_PRODUCTION_TEMPLATE)) {
             generateNginxConfig(NGINX_PRODUCTION_TEMPLATE, NGINX_PRODUCTION_OUTPUT, cspFrameSrc);
         } else {
-            console.warn(`Nginx production template not found: ${NGINX_PRODUCTION_TEMPLATE}`);
+            const message = `Nginx production template not found: ${NGINX_PRODUCTION_TEMPLATE}`;
+            if (STRICT_MODE) {
+                console.error('❌ ' + message);
+                console.error('   Set CSP_GEN_STRICT=false to make nginx configs optional');
+                throw new Error(message);
+            } else {
+                console.warn('⚠️  ' + message);
+            }
         }
 
         if (fs.existsSync(NGINX_STAGING_TEMPLATE)) {
             generateNginxConfig(NGINX_STAGING_TEMPLATE, NGINX_STAGING_OUTPUT, cspFrameSrc);
         } else {
-            console.warn(`Nginx staging template not found: ${NGINX_STAGING_TEMPLATE}`);
+            const message = `Nginx staging template not found: ${NGINX_STAGING_TEMPLATE}`;
+            if (STRICT_MODE) {
+                console.error('❌ ' + message);
+                console.error('   Set CSP_GEN_STRICT=false to make nginx configs optional');
+                throw new Error(message);
+            } else {
+                console.warn('⚠️  ' + message);
+            }
         }
+
+        // Validate all generated files
+        validateGeneratedFiles();
 
         console.log('\n✅ Configuration generation completed successfully!');
         console.log('\nNext steps:');


### PR DESCRIPTION
- **Consolidate trusted embed domains into single source of truth**
- **Add integration tests for CSP headers for embeds.**
- **Fix CSP generation in all Docker environments and add security tests**
- **Add prebuild to test commands.**
- **Add more build steps to ensure CSM configs are generated with build and part deployment process.**
